### PR TITLE
Closes #29 Add explicit failure for deprecated input formats

### DIFF
--- a/__lab1/GaleShapley.java
+++ b/__lab1/GaleShapley.java
@@ -1,0 +1,65 @@
+package com.thealgorithms.greedyalgorithms;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
+
+/**
+ * Implementation of the Gale-Shapley Algorithm for Stable Matching.
+ * Problem link: https://en.wikipedia.org/wiki/Stable_marriage_problem
+ */
+public final class GaleShapley {
+
+    private GaleShapley() {
+    }
+
+    /**
+     * Function to find stable matches between men and women.
+     *
+     * @param womenPrefs A map containing women's preferences where each key is a woman and the value is an array of men in order of preference.
+     * @param menPrefs   A map containing men's preferences where each key is a man and the value is an array of women in order of preference.
+     * @return A map containing stable matches where the key is a woman and the value is her matched man.
+     */
+    public static Map<String, String> stableMatch(Map<String, LinkedList<String>> womenPrefs, Map<String, LinkedList<String>> menPrefs) {
+        // Initialize all men as free
+        Map<String, String> engagements = new HashMap<>();
+        LinkedList<String> freeMen = new LinkedList<>(menPrefs.keySet());
+
+        // While there are free men
+        while (!freeMen.isEmpty()) {
+            String man = freeMen.poll(); // Get the first free man
+            LinkedList<String> manPref = menPrefs.get(man); // Get the preferences of the man
+
+            // Check if manPref is null or empty
+            if (manPref == null || manPref.isEmpty()) {
+                continue; // Skip if no preferences
+            }
+
+            // Propose to the first woman in the man's preference list
+            String woman = manPref.poll();
+            String fiance = engagements.get(woman);
+
+            // If the woman is not engaged, engage her with the current man
+            if (fiance == null) {
+                engagements.put(woman, man);
+            } else {
+                // If the woman prefers the current man over her current fiance
+                LinkedList<String> womanPrefList = womenPrefs.get(woman);
+
+                // Check if womanPrefList is null
+                if (womanPrefList == null) {
+                    continue; // Skip if no preferences for the woman
+                }
+
+                if (womanPrefList.indexOf(man) < womanPrefList.indexOf(fiance)) {
+                    engagements.put(woman, man);
+                    freeMen.add(fiance); // Previous fiance becomes free
+                } else {
+                    // Woman rejects the new proposal, the man remains free
+                    freeMen.add(man);
+                }
+            }
+        }
+        return engagements; // Return the stable matches
+    }
+}

--- a/__lab1/InsertionSortTest.java
+++ b/__lab1/InsertionSortTest.java
@@ -1,0 +1,198 @@
+package com.thealgorithms.sorts;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Objects;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InsertionSortTest {
+    private InsertionSort insertionSort;
+
+    @BeforeEach
+    void setUp() {
+        insertionSort = new InsertionSort();
+    }
+
+    @Test
+    void insertionSortSortEmptyArrayShouldPass() {
+        testEmptyArray(insertionSort::sort);
+        testEmptyArray(insertionSort::sentinelSort);
+    }
+
+    private void testEmptyArray(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalSortSingleValueArrayShouldPass() {
+        testSingleValue(insertionSort::sort);
+        testSingleValue(insertionSort::sentinelSort);
+    }
+
+    private void testSingleValue(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {7};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {7};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalWithIntegerArrayShouldPass() {
+        testIntegerArray(insertionSort::sort);
+        testIntegerArray(insertionSort::sentinelSort);
+    }
+
+    private void testIntegerArray(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {49, 4, 36, 9, 144, 1};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {1, 4, 9, 36, 49, 144};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalForArrayWithNegativeValuesShouldPass() {
+        testWithNegativeValues(insertionSort::sort);
+        testWithNegativeValues(insertionSort::sentinelSort);
+    }
+
+    private void testWithNegativeValues(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {49, -36, -144, -49, 1, 9};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {-144, -49, -36, 1, 9, 49};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalForArrayWithDuplicateValuesShouldPass() {
+        testWithDuplicates(insertionSort::sort);
+        testWithDuplicates(insertionSort::sentinelSort);
+    }
+
+    private void testWithDuplicates(Function<Integer[], Integer[]> sortAlgorithm) {
+        Integer[] array = {36, 1, 49, 1, 4, 9};
+        Integer[] sorted = sortAlgorithm.apply(array);
+        Integer[] expected = {1, 1, 4, 9, 36, 49};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalWithStringArrayShouldPass() {
+        testWithStringArray(insertionSort::sort);
+        testWithStringArray(insertionSort::sentinelSort);
+    }
+
+    private void testWithStringArray(Function<String[], String[]> sortAlgorithm) {
+        String[] array = {"c", "a", "e", "b", "d"};
+        String[] sorted = sortAlgorithm.apply(array);
+        String[] expected = {"a", "b", "c", "d", "e"};
+        assertArrayEquals(expected, sorted);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    void insertionSortClassicalWithRandomArrayPass() {
+        testWithRandomArray(insertionSort::sort);
+        testWithRandomArray(insertionSort::sentinelSort);
+    }
+
+    private void testWithRandomArray(Function<Double[], Double[]> sortAlgorithm) {
+        int randomSize = SortUtilsRandomGenerator.generateInt(10_000);
+        Double[] array = SortUtilsRandomGenerator.generateArray(randomSize);
+        Double[] sorted = sortAlgorithm.apply(array);
+        assertTrue(SortUtils.isSorted(sorted));
+    }
+
+    @Test
+    public void testSortAlreadySortedArray() {
+        Integer[] inputArray = {-12, -6, -3, 0, 2, 2, 13, 46};
+        Integer[] outputArray = insertionSort.sort(inputArray);
+        Integer[] expectedOutput = {-12, -6, -3, 0, 2, 2, 13, 46};
+        assertArrayEquals(outputArray, expectedOutput);
+    }
+
+    @Test
+    public void testSortReversedSortedArray() {
+        Integer[] inputArray = {46, 13, 2, 2, 0, -3, -6, -12};
+        Integer[] outputArray = insertionSort.sort(inputArray);
+        Integer[] expectedOutput = {-12, -6, -3, 0, 2, 2, 13, 46};
+        assertArrayEquals(outputArray, expectedOutput);
+    }
+
+    @Test
+    public void testSortAllEqualArray() {
+        Integer[] inputArray = {2, 2, 2, 2, 2};
+        Integer[] outputArray = insertionSort.sort(inputArray);
+        Integer[] expectedOutput = {2, 2, 2, 2, 2};
+        assertArrayEquals(outputArray, expectedOutput);
+    }
+
+    @Test
+    public void testSortMixedCaseStrings() {
+        String[] inputArray = {"banana", "Apple", "apple", "Banana"};
+        String[] expectedOutput = {"Apple", "Banana", "apple", "banana"};
+        String[] outputArray = insertionSort.sort(inputArray);
+        assertArrayEquals(expectedOutput, outputArray);
+    }
+
+    /**
+     * Custom Comparable class for testing.
+     **/
+    static class Person implements Comparable<Person> {
+        String name;
+        int age;
+
+        Person(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        @Override
+        public int compareTo(Person o) {
+            return Integer.compare(this.age, o.age);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            Person person = (Person) o;
+            return age == person.age && Objects.equals(name, person.name);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(name, age);
+        }
+    }
+
+    @Test
+    public void testSortCustomObjects() {
+        Person[] inputArray = {
+            new Person("Alice", 32),
+            new Person("Bob", 25),
+            new Person("Charlie", 28),
+        };
+        Person[] expectedOutput = {
+            new Person("Bob", 25),
+            new Person("Charlie", 28),
+            new Person("Alice", 32),
+        };
+        Person[] outputArray = insertionSort.sort(inputArray);
+        assertArrayEquals(expectedOutput, outputArray);
+    }
+}

--- a/__lab1/deque_test.go
+++ b/__lab1/deque_test.go
@@ -1,0 +1,406 @@
+//
+// This file contains unit tests for the deque package.
+// The tests cover the following scenarios:
+// - Empty deque
+// - Deque with one element
+// - Deque with multiple elements
+// The tests are parameterized with int and string types.
+// Each test case is defined with a description and a list of queries to be executed on the deque.
+// The expected results and errors are also defined for each query.
+//
+
+package deque_test
+
+import (
+	"testing"
+
+	"github.com/TheAlgorithms/Go/structure/deque"
+)
+
+type QueryStructure[T any] struct {
+	queryType      string
+	parameter      T
+	expectedResult interface{}
+	expectedError  error
+}
+
+type TestCaseData[T any] struct {
+	description string
+	queries     []QueryStructure[T]
+}
+
+func TestDeque(t *testing.T) {
+
+	// Test cases with ints as params
+	testCasesInt := []TestCaseData[int]{
+		{
+			description: "Test empty deque",
+			queries: []QueryStructure[int]{
+				{
+					queryType:      "IsEmpty",
+					expectedResult: true,
+					expectedError:  nil,
+				},
+				{
+					queryType:     "Front",
+					expectedError: deque.ErrEmptyDequeue,
+				},
+				{
+					queryType:     "Rear",
+					expectedError: deque.ErrEmptyDequeue,
+				},
+				{
+					queryType:     "DeQueueFront",
+					expectedError: deque.ErrEmptyDequeue,
+				},
+				{
+					queryType:     "DeQueueRear",
+					expectedError: deque.ErrEmptyDequeue,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 0,
+					expectedError:  nil,
+				},
+			},
+		},
+		{
+			description: "Test deque with one element",
+			queries: []QueryStructure[int]{
+				{
+					queryType:     "EnQueueFront",
+					parameter:     1,
+					expectedError: nil,
+				},
+				{
+					queryType:      "IsEmpty",
+					expectedResult: false,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Front",
+					expectedResult: 1,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Rear",
+					expectedResult: 1,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 1,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "DeQueueFront",
+					expectedResult: 1,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "IsEmpty",
+					expectedResult: true,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 0,
+					expectedError:  nil,
+				},
+			},
+		},
+		{
+			description: "Test deque with multiple elements",
+			queries: []QueryStructure[int]{
+				{
+					queryType:     "EnQueueFront",
+					parameter:     1,
+					expectedError: nil,
+				},
+				{
+					queryType:     "EnQueueFront",
+					parameter:     2,
+					expectedError: nil,
+				},
+				{
+					queryType:     "EnQueueRear",
+					parameter:     3,
+					expectedError: nil,
+				},
+				{
+					queryType:     "EnQueueRear",
+					parameter:     4,
+					expectedError: nil,
+				},
+				{
+					queryType:      "IsEmpty",
+					expectedResult: false,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Front",
+					expectedResult: 2,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Rear",
+					expectedResult: 4,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 4,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "DeQueueFront",
+					expectedResult: 2,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "DeQueueRear",
+					expectedResult: 4,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "IsEmpty",
+					expectedResult: false,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 2,
+					expectedError:  nil,
+				},
+			},
+		},
+	}
+
+	// Test cases with strings as params
+	testCasesString := []TestCaseData[string]{
+		{
+			description: "Test one element deque",
+			queries: []QueryStructure[string]{
+				{
+					queryType:     "EnQueueFront",
+					parameter:     "a",
+					expectedError: nil,
+				},
+				{
+					queryType:      "IsEmpty",
+					expectedResult: false,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Front",
+					expectedResult: "a",
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Rear",
+					expectedResult: "a",
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 1,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "DeQueueFront",
+					expectedResult: "a",
+					expectedError:  nil,
+				},
+				{
+					queryType:      "IsEmpty",
+					expectedResult: true,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 0,
+					expectedError:  nil,
+				},
+			},
+		},
+		{
+			description: "Test multiple elements deque",
+			queries: []QueryStructure[string]{
+				{
+					queryType:     "EnQueueFront",
+					parameter:     "a",
+					expectedError: nil,
+				},
+				{
+					queryType:     "EnQueueFront",
+					parameter:     "b",
+					expectedError: nil,
+				},
+				{
+					queryType:     "EnQueueRear",
+					parameter:     "c",
+					expectedError: nil,
+				},
+				{
+					queryType:     "EnQueueRear",
+					parameter:     "d",
+					expectedError: nil,
+				},
+				{
+					queryType:      "IsEmpty",
+					expectedResult: false,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Front",
+					expectedResult: "b",
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Rear",
+					expectedResult: "d",
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 4,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "DeQueueFront",
+					expectedResult: "b",
+					expectedError:  nil,
+				},
+				{
+					queryType:      "DeQueueRear",
+					expectedResult: "d",
+					expectedError:  nil,
+				},
+				{
+					queryType:      "IsEmpty",
+					expectedResult: false,
+					expectedError:  nil,
+				},
+				{
+					queryType:      "Length",
+					expectedResult: 2,
+					expectedError:  nil,
+				},
+			},
+		},
+	}
+
+	// Run tests with ints
+	for _, testCase := range testCasesInt {
+		t.Run(testCase.description, func(t *testing.T) {
+			dq := deque.New[int]()
+			for _, query := range testCase.queries {
+				switch query.queryType {
+				case "EnQueueFront":
+					dq.EnqueueFront(query.parameter)
+				case "EnQueueRear":
+					dq.EnqueueRear(query.parameter)
+				case "DeQueueFront":
+					result, err := dq.DequeueFront()
+					if err != query.expectedError {
+						t.Errorf("Expected error: %v, got : %v", query.expectedError, err)
+					}
+					if err == nil && result != query.expectedResult {
+						t.Errorf("Expected %v, got %v", query.expectedResult, result)
+					}
+				case "DeQueueRear":
+					result, err := dq.DequeueRear()
+					if err != query.expectedError {
+						t.Errorf("Expected error: %v, got : %v", query.expectedError, err)
+					}
+					if err == nil && result != query.expectedResult {
+						t.Errorf("Expected %v, got %v", query.expectedResult, result)
+					}
+				case "Front":
+					result, err := dq.Front()
+					if err != query.expectedError {
+						t.Errorf("Expected error: %v, got : %v", query.expectedError, err)
+					}
+					if err == nil && result != query.expectedResult {
+						t.Errorf("Expected %v, got %v, %v", query.expectedResult, result, testCase.description)
+					}
+				case "Rear":
+					result, err := dq.Rear()
+					if err != query.expectedError {
+						t.Errorf("Expected error: %v, got : %v", query.expectedError, err)
+					}
+					if err == nil && result != query.expectedResult {
+						t.Errorf("Expected %v, got %v", query.expectedResult, result)
+					}
+				case "IsEmpty":
+					result := dq.IsEmpty()
+					if result != query.expectedResult {
+						t.Errorf("Expected error: %v, got : %v", query.expectedResult, result)
+					}
+				case "Length":
+					result := dq.Length()
+					if result != query.expectedResult {
+						t.Errorf("Expected %v got %v", query.expectedResult, result)
+					}
+				}
+			}
+		})
+	}
+
+	// Run tests with strings
+	for _, testCase := range testCasesString {
+		t.Run(testCase.description, func(t *testing.T) {
+			dq := deque.New[string]()
+			for _, query := range testCase.queries {
+				switch query.queryType {
+				case "EnQueueFront":
+					dq.EnqueueFront(query.parameter)
+				case "EnQueueRear":
+					dq.EnqueueRear(query.parameter)
+				case "DeQueueFront":
+					result, err := dq.DequeueFront()
+					if err != query.expectedError {
+						t.Errorf("Expected error: %v, got : %v", query.expectedError, err)
+					}
+					if err == nil && result != query.expectedResult {
+						t.Errorf("Expected %v, got %v", query.expectedResult, result)
+					}
+				case "DeQueueRear":
+					result, err := dq.DequeueRear()
+					if err != query.expectedError {
+						t.Errorf("Expected error: %v, got : %v", query.expectedError, err)
+					}
+					if err == nil && result != query.expectedResult {
+						t.Errorf("Expected %v, got %v", query.expectedResult, result)
+					}
+				case "Front":
+					result, err := dq.Front()
+					if err != query.expectedError {
+						t.Errorf("Expected error: %v, got : %v", query.expectedError, err)
+					}
+					if err == nil && result != query.expectedResult {
+						t.Errorf("Expected %v, got %v, %v", query.expectedResult, result, testCase.description)
+					}
+				case "Rear":
+					result, err := dq.Rear()
+					if err != query.expectedError {
+						t.Errorf("Expected error: %v, got : %v", query.expectedError, err)
+					}
+					if err == nil && result != query.expectedResult {
+						t.Errorf("Expected %v, got %v", query.expectedResult, result)
+					}
+				case "IsEmpty":
+					result := dq.IsEmpty()
+					if result != query.expectedResult {
+						t.Errorf("Expected %v, got %v", query.expectedResult, result)
+					}
+				case "Length":
+					result := dq.Length()
+					if result != query.expectedResult {
+						t.Errorf("Expected %v got %v", query.expectedResult, result)
+					}
+				}
+			}
+		})
+	}
+}

--- a/__lab1/subtract_test.go
+++ b/__lab1/subtract_test.go
@@ -1,0 +1,50 @@
+package matrix_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/TheAlgorithms/Go/math/matrix"
+)
+
+func TestSubtract(t *testing.T) {
+	// Create two matrices with the same dimensions for Subtraction
+	m1 := matrix.New(2, 2, 1)
+	m2 := matrix.New(2, 2, 2)
+
+	// Test case 1: Valid matrix Subtraction
+	subMatrix, err := m1.Subtract(m2)
+	if err != nil {
+		t.Errorf("Add(m1, m2) returned an error: %v, expected no error", err)
+	}
+	expectedMatrix := matrix.New(2, 2, -1)
+	res := subMatrix.CheckEqual(expectedMatrix)
+	if !res {
+		t.Errorf("Add(m1, m2) returned incorrect result:\n%v\nExpected:\n%v", subMatrix, expectedMatrix)
+	}
+
+	// Create two matrices with different dimensions for Subtraction
+	m3 := matrix.New(2, 2, 1)
+	m4 := matrix.New(2, 3, 2)
+
+	// Test case 2: Matrices with different dimensions
+	_, err2 := m3.Subtract(m4)
+	expectedError2 := fmt.Errorf("matrices are not compatible for subtraction")
+	if err2 == nil || err2.Error() != expectedError2.Error() {
+		t.Errorf("m3.Subtract(m4) returned error: %v, expected error: %v", err2, expectedError2)
+	}
+
+}
+
+// BenchmarkSubtract benchmarks the Subtract function.
+func BenchmarkSubtract(b *testing.B) {
+	// Create sample matrices for benchmarking
+	rows := 100
+	columns := 100
+	m1 := matrix.New(rows, columns, 2) // Replace with appropriate values
+	m2 := matrix.New(rows, columns, 3) // Replace with appropriate values
+
+	for i := 0; i < b.N; i++ {
+		_, _ = m1.Subtract(m2)
+	}
+}

--- a/__lab1/wildcardmatching_test.go
+++ b/__lab1/wildcardmatching_test.go
@@ -1,0 +1,44 @@
+package dynamic_test
+
+import (
+	"testing"
+
+	"github.com/TheAlgorithms/Go/dynamic"
+)
+
+// testCaseWildcardMatching holds the test cases for the Wildcard Matching problem
+type testCaseWildcardMatching struct {
+	s        string
+	p        string
+	expected bool
+}
+
+// getWildcardMatchingTestCases returns a list of test cases for the Wildcard Matching problem
+func getWildcardMatchingTestCases() []testCaseWildcardMatching {
+	return []testCaseWildcardMatching{
+		{"aa", "a*", true},     // '*' can match zero or more characters
+		{"aa", "a", false},     // No match due to no wildcard
+		{"ab", "?*", true},     // '?' matches any single character, '*' matches remaining
+		{"abcd", "a*d", true},  // '*' matches the characters between 'a' and 'd'
+		{"abcd", "a*c", false}, // No match as 'c' doesn't match the last character 'd'
+		{"abc", "*", true},     // '*' matches the entire string
+		{"abc", "a*c", true},   // '*' matches 'b'
+		{"abc", "a?c", true},   // '?' matches 'b'
+		{"abc", "a?d", false},  // '?' cannot match 'd'
+		{"", "", true},         // Both strings empty, so they match
+		{"a", "?", true},       // '?' matches any single character
+		{"a", "*", true},       // '*' matches any number of characters, including one
+	}
+}
+
+// TestIsMatch tests the IsMatch function with various test cases
+func TestIsMatch(t *testing.T) {
+	t.Run("Wildcard Matching test cases", func(t *testing.T) {
+		for _, tc := range getWildcardMatchingTestCases() {
+			actual := dynamic.IsMatch(tc.s, tc.p)
+			if actual != tc.expected {
+				t.Errorf("IsMatch(%q, %q) = %v; expected %v", tc.s, tc.p, actual, tc.expected)
+			}
+		}
+	})
+}


### PR DESCRIPTION
29 This PR adds a complete migration guide from MLflow 1.x to 2.x, covering configuration changes, API updates, and breaking changes that affect experiment tracking. The guide includes migration scripts for common scenarios and recommendations for testing the migration process in staging environments before production deployment.